### PR TITLE
Remove explicit gatsby-link dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-bootstrap-netlify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "gatsby-starter-bootstrap-netlify",
   "description": "Example Gatsby, Bootstrap, and Netlify CMS project",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "David Konsumer <konsumer@jetboystudio.com>",
   "dependencies": {
     "bootstrap": "^4.1.3",
     "bootswatch": "4.*",
     "gatsby": "^2.0.63",
-    "gatsby-link": "^2.0.7",
     "gatsby-plugin-netlify": "^2.0.6",
     "gatsby-plugin-offline": "^2.0.18",
     "gatsby-plugin-react-helmet": "^3.0.4",

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Container } from 'reactstrap'
 import PropTypes from 'prop-types'
-import Link from 'gatsby-link'
 import Helmet from 'react-helmet'
-import { StaticQuery, graphql } from 'gatsby'
+import { graphql, Link, StaticQuery } from 'gatsby'
 
 // code syntax-highlighting theme
 // feel free to change it to another one

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Container, Card, CardText, CardBody, CardTitle, CardSubtitle } from 'reactstrap'
-import Link from 'gatsby-link'
-import { graphql } from 'gatsby'
+import { graphql, Link } from 'gatsby'
 import Layout from '../components/layout'
 
 const IndexPage = ({ data }) => {

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Container, Card, CardTitle, CardGroup, CardBody } from 'reactstrap'
 import Helmet from 'react-helmet'
 import { basename } from 'path'
-import Link from 'gatsby-link'
-import { graphql } from 'gatsby'
+import { graphql, Link } from 'gatsby'
 import Layout from '../components/layout'
 
 // find a post title by path


### PR DESCRIPTION
In Gatsby v2, gatsby-link is managed by (and therefore imported from) Gatsby. This removes the explicit dependency and switches the `import` statements.